### PR TITLE
Extend the static authority's #valid_credentials! to set more user attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,14 @@
 Aker History
 ============
 
-3.0.5
+3.1.0
 -----
+
+- Added: Aker::Authorities::Static#valid_credentials! now can set any user
+  attribute, including portal and group memberships.  (#25)
+
+- Changed: Aker::Authorities::Static#load! now raises on invalid user
+  attributes.
 
 3.0.4
 -----

--- a/aker.gemspec
+++ b/aker.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |s|
   # general
   s.add_dependency 'rubytree', '~> 0.7.0'
   s.add_dependency 'activesupport', '>= 2.3.0'
+  s.add_dependency 'blankslate'
   s.add_dependency 'i18n', '~> 0.4'
 
   # ldap

--- a/lib/aker/authorities/static.rb
+++ b/lib/aker/authorities/static.rb
@@ -211,7 +211,13 @@ module Aker::Authorities
         attr_keys = config.keys - ["password", "portals", "identifiers"]
 
         valid_credentials!(:user, username, config["password"]) do |u|
-          attr_keys.each { |k| u.send("#{k}=", config[k]) }
+          attr_keys.each do |k|
+            begin
+              u.send("#{k}=", config[k])
+            rescue NoMethodError
+              raise NoMethodError, "#{k} is not a recognized user attribute"
+            end
+          end
 
           portal_data = config["portals"] || []
 

--- a/lib/aker/version.rb
+++ b/lib/aker/version.rb
@@ -1,3 +1,3 @@
 module Aker
-  VERSION = '3.0.5.pre'
+  VERSION = '3.1.0.pre'
 end

--- a/spec/aker/authorities/static_spec.rb
+++ b/spec/aker/authorities/static_spec.rb
@@ -351,6 +351,18 @@ module Aker::Authorities
           @s.valid_credentials?(:user, "jo", "qofhearts").should be_true
         end
 
+        it "raises when an unknown user attribute is encountered" do
+          test = lambda do
+            @s.load!(StringIO.new(<<-YAML))
+              users:
+                jo:
+                  foobar: 1
+            YAML
+          end
+
+          test.should raise_error("foobar is not a recognized user attribute")
+        end
+
         describe "user attributes" do
           before do
             @jo = @s.user("jo")


### PR DESCRIPTION
`Aker::Authorities::Static#valid_credentials!` is the supported way of adding users to a static authority.  We should be able to set additional user attributes with it, such as group memberships.

(Maybe it'd make sense to rename #valid_credentials! and add an alias with a deprecation warning, too.)

Something like this:

``` ruby
auth.valid_credentials!(:user, "foo", "bar") do |u|
  u.in_group!(:NOTIS, "Manager", :affiliate_ids => [20, 30])
  u.first_name = "Foo"
end
```

Machine account handling in https://github.com/NUBIC/ncs_staff_portal is motivating this feature.  This could also simplify `Aker::Authorities::Static#load!`.
