### PR TITLE
Use a custom CAS server for CAS integration tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,12 +49,9 @@ group :development do
   gem 'ladle', '~> 0.2'
 
   # cas testing
-  # although we use activerecord directly, declaring it here without a
-  # version causes one form of infinite resolving in bundler.
-  # gem 'activerecord'
-  gem 'rubycas-server', :require => 'casserver',
-    :git => 'git://github.com/NUBIC/rubycas-server.git', :ref => 'cedf6cd'
-  gem 'sinatra', '~> 1.2.0', :require => false
+  gem 'sinatra', :require => false
+  gem 'escape_utils', :require => false
+
   platforms :jruby do
     gem 'jdbc-sqlite3'
     gem 'activerecord-jdbcsqlite3-adapter', '~> 1.1'

--- a/features/support/controllable_cas_server.rb
+++ b/features/support/controllable_cas_server.rb
@@ -1,21 +1,5 @@
-require 'rack/builder'
-require 'yaml'
-require 'fileutils'
-require 'active_record' # see below
-require File.expand_path("../controllable_rack_server.rb", __FILE__)
-
-# Because rubycas-server's config.ru refers to the Rack module, it
-# needs to be interpreted outside of the Aker module.
-module CASServer
-  def self.app(config_filename)
-    ENV['CONFIG_FILE'] = config_filename
-
-    rackup = File.expand_path("../config.ru",
-                              $LOAD_PATH.detect { |path| path =~ /rubycas-server/ })
-
-    ::Rack::Builder.parse_file(rackup).first
-  end
-end
+require File.expand_path('../controllable_rack_server', __FILE__)
+require File.expand_path('../ssl_env', __FILE__)
 
 module Aker
   module Cucumber
@@ -25,60 +9,35 @@ module Aker
       attr_reader :users_database_filename
 
       def initialize(tmpdir, port)
-        super(:port => port, :tmpdir => tmpdir, :ssl => true, :app_creator => lambda {
-                CASServer.app(create_server_config(binding))
-              })
-      end
-
-      def start
-        @users_database_filename = create_user_database
-        super
-      end
-
-      def stop
-        PrivateModel.connection_handler.clear_all_connections!
-        super
+        super(:port => port, :tmpdir => tmpdir, :ssl => true, :app => TestCasServer)
       end
 
       def register_user(username, password)
-        PrivateModel.connection.
-          update("INSERT INTO users (username, password) VALUES ('#{username}', '#{password}')")
+        post! URI.parse("#{base_url}/_accept") do |req|
+          req.set_form_data('username' => username, 'password' => password)
+        end
+      end
+
+      def reset
+        post! URI.parse("#{base_url}/_reset")
       end
 
       protected
 
+      def post!(uri)
+        http = Net::HTTP.new(uri.host, uri.port)
+        http.use_ssl = ssl?
+        http.cert = ssl_env.certificate
+
+        req = Net::HTTP::Post.new(uri.path)
+        yield req if block_given?
+
+        resp = http.request(req)
+        raise "Expected 2xx from POST #{uri}, got #{resp.code}" unless Net::HTTPSuccess === resp
+      end
+
       def log_filename
         "cas-out.log"
-      end
-
-      private
-
-      def active_record_adapter
-        (RUBY_PLATFORM == 'java' ? 'jdbcsqlite3' : 'sqlite3')
-      end
-
-      def create_user_database
-        File.join(tmpdir, 'cas-users.db').tap do |fn|
-          rm fn if File.exist?(fn)
-          PrivateModel.establish_connection :database => fn, :adapter => active_record_adapter
-          PrivateModel.connection.update("CREATE TABLE users (username, password)")
-        end
-      end
-
-      def create_server_config(scope)
-        File.join(tmpdir, 'cas-config.yml').tap do |fn|
-          File.open(fn, 'w') do |f|
-            f.write(ERB.new(File.read(File.expand_path("../casserver.yml.erb", __FILE__))).
-              result(scope))
-          end
-        end
-      end
-
-      # This class is used to provide an isolated point to use to
-      # build the connection to the user database.  This hack is
-      # required because jdbc-sqlite3 is wholly undocumented, so I
-      # can't do JRuby compat without using an AR connection.
-      class PrivateModel < ActiveRecord::Base
       end
     end
   end

--- a/features/support/controllable_rack_server.rb
+++ b/features/support/controllable_rack_server.rb
@@ -2,6 +2,7 @@ require File.expand_path('../spawned_http_server.rb', __FILE__)
 
 module Aker::Cucumber
   class ControllableRackServer < SpawnedHttpServer
+    attr_reader :ssl_env
     attr_accessor :app
 
     def initialize(options={})
@@ -31,7 +32,7 @@ module Aker::Cucumber
 
       options = { :Port => port }
       if ssl?
-        options.merge!(SslEnv.new.webrick_ssl)
+        options.merge!(ssl_env.webrick_ssl)
       end
 
       a = app

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -21,7 +21,6 @@ Before do
     logger Logger.new(aker_log)
   }
   ar_log = "#{tmpdir}/active_record.log"
-  ActiveRecord::Base.logger = Logger.new(ar_log)
 end
 
 Before('@cas') do
@@ -33,6 +32,7 @@ Before('@ldap') do
 end
 
 After do
+  reset_cas_server
   stop_spawned_servers
   stop_ladle_server
 end
@@ -137,6 +137,10 @@ module Aker::Cucumber
       self.spawned_servers << @cas_server
       @cas_server.start
       @cas_server
+    end
+
+    def reset_cas_server
+      @cas_server.reset if @cas_server
     end
 
     # @return [Aker::Cucumber::ControllableRackServer]

--- a/features/support/spawned_http_server.rb
+++ b/features/support/spawned_http_server.rb
@@ -30,6 +30,7 @@ module Aker
                    @timeout)
           Process.detach(@pid)
         else
+          Dir.chdir(@tmpdir)
           exec_server
         end
       end

--- a/features/support/test_cas.rb
+++ b/features/support/test_cas.rb
@@ -1,0 +1,276 @@
+require 'net/http'
+require 'rack/utils'
+require 'securerandom'
+require 'sinatra'
+require 'yaml'
+
+class TestCasServer < Sinatra::Base
+  include Rack::Utils
+
+  attr_reader :tickets
+  attr_reader :credentials
+
+  enable :sessions
+  set :session_secret, 'supersekrit'
+
+  class Ticket < Struct.new(:service, :nonce, :username, :proxies, :used)
+    alias_method :used?, :used
+  end
+
+  def initialize(*)
+    super
+
+    @tickets = {}
+    @credentials = {}
+
+    @ticket_file = "#{Dir.pwd}/tickets.yml"
+    @credentials_file = "#{Dir.pwd}/credentials.yml"
+
+    load_state
+  end
+
+  def load_state
+    if File.exists?(@ticket_file)
+      tickets.update(YAML.load_file(@ticket_file))
+    end
+
+    if File.exists?(@credentials_file)
+      credentials.update(YAML.load_file(@credentials_file))
+    end
+  end
+
+  def save_state
+    File.open(@ticket_file, 'w') { |f| f.write(tickets.to_yaml) }
+    File.open(@credentials_file, 'w') { |f| f.write(credentials.to_yaml) }
+  end
+
+  def nonce(prefix = '')
+    # SecureRandom.urlsafe_base64 may generate non-kosher characters like _, so
+    # we restrict ourselves to hex digits
+    prefix + "-" + SecureRandom.hex(64)
+  end
+
+  def gen_ticket(service, nonce, username, proxies = [])
+    Ticket.new(service, nonce, username, proxies).tap do |t|
+      tickets[[service, nonce]] = t
+      save_state
+    end
+  end
+
+  def append(service, ticket)
+    uri = URI.parse(service)
+    qhash = Rack::Utils.parse_query(uri.query)
+    qhash['ticket'] = ticket.nonce
+    uri.query = Rack::Utils.build_query(qhash)
+    uri.to_s
+  end
+
+  def ticket_for(service, nonce)
+    tickets[[service, nonce]]
+  end
+
+  def tgt(session)
+    ticket_for(:any, session['tgt'])
+  end
+
+  def gen_tgt(session, username)
+    ticket = gen_ticket(:any, nonce('TGT'), username)
+    session['tgt'] = ticket.nonce
+  end
+
+  def gen_pgt(callback_url, st)
+    pgt_iou = gen_ticket(:any, nonce('PGTIOU'), st.username)
+    pgt = gen_ticket(:any, 'PGT', st.username)
+
+    url = URI.parse(callback_url).tap do |u|
+      u.query = build_query(:pgtId => pgt.nonce, :pgtIou => pgt_iou.nonce)
+    end
+
+    h = Net::HTTP.new(url.host, url.port).tap do |h|
+      h.verify_mode = OpenSSL::SSL::VERIFY_NONE
+      h.use_ssl = true
+    end
+
+    resp = h.get(url)
+    raise 'PGT generation failed' unless Net::HTTPSuccess === resp
+
+    [pgt, pgt_iou]
+  end
+
+  def mandate(request, params)
+    missing = params.select { |p| !request[p] || request[p].empty? }
+
+    if !missing.empty?
+      raise "Missing required parameters #{missing.join(', ')}"
+    end
+  end
+
+  post '/_reset' do
+    tickets.clear
+    credentials.clear
+    save_state
+
+    status 204
+  end
+
+  post '/_accept' do
+    username = request['username']
+    password = request['password']
+
+    credentials[username] = password
+    save_state
+
+    status 201
+  end
+
+  get '/' do
+    redirect '/login'
+  end
+
+  get '/login' do
+    if tgt(session)
+      call env.merge('REQUEST_METHOD' => 'POST')
+    else
+      service = request['service'] || ''
+
+      content_type :html
+      status 200
+
+      %Q{
+        <!DOCTYPE html>
+        <html>
+          <head>
+            <title>CAS</title>
+          </head>
+          <body>
+            <form method="POST" action="/login">
+              <input type="text" name="username">
+              <input type="password" name="password">
+              <input type="hidden" name="lt" value="useless">
+              <input type="hidden" name="service" value="#{service}">
+              <input type="submit">
+            </form>
+          </body>
+        </html>
+      }
+    end
+  end
+
+  get '/logout' do
+    session.clear
+
+    "You have successfully logged out"
+  end
+
+  post '/login' do
+    if (tgt = tgt(session))
+      service = request['service']
+
+      if service && !service.empty?
+        ticket = gen_ticket(service, nonce('ST'), tgt.username)
+        target = append(service, ticket)
+        redirect target
+      else
+        status 200
+        "You have successfully logged in"
+      end
+    else
+      mandate request, %w(username password)
+
+      username = request['username']
+      password = request['password']
+      service = request['service']
+
+      if credentials.has_key?(username) && credentials[username] == password
+        gen_tgt(session, username)
+        call env
+      else
+        status 401
+        "Unauthorized"
+      end
+    end
+  end
+
+  get '/serviceValidate' do
+    mandate request, %w(service ticket)
+
+    service = request['service']
+    nonce = request['ticket']
+    callback_url = request['pgtUrl']
+
+    ticket = ticket_for(service, nonce)
+
+    if ticket && !ticket.used?
+      ticket.used = true
+
+      status 200
+
+      if callback_url && !callback_url.empty?
+        pgt, pgt_iou = gen_pgt(callback_url, ticket)
+
+        %Q{
+          <cas:serviceResponse xmlns:cas="http://www.yale.edu/tp/cas">
+            <cas:authenticationSuccess>
+              <cas:user>#{ticket.username}</cas:user>
+              <cas:proxyGrantingTicket>#{pgt_iou.nonce}</cas:proxyGrantingTicket>
+            </cas:authenticationSuccess>
+          </cas:serviceResponse>
+        }
+      else
+        %Q{
+          <cas:serviceResponse xmlns:cas="http://www.yale.edu/tp/cas">
+            <cas:authenticationSuccess>
+              <cas:user>#{ticket.username}</cas:user>
+            </cas:authenticationSuccess>
+          </cas:serviceResponse>
+        }
+      end
+    else
+      status 401
+
+      %Q{
+        <cas:serviceResponse xmlns:cas="http://www.yale.edu/tp/cas">
+          <cas:authenticationFailure code="INVALID_TICKET">
+          </cas:authenticationFailure>
+        </cas:serviceResponse>
+      }
+    end
+  end
+
+  get '/proxyValidate' do
+    call env.merge('PATH_INFO' => '/serviceValidate')
+  end
+
+  get '/proxy' do
+    mandate request, %w(pgt targetService)
+
+    pgt = request['pgt']
+    service = request['targetService']
+
+    ticket = ticket_for(:any, pgt)
+
+    if ticket
+      pt = gen_ticket(service, nonce('PT'), ticket.username, [request.ip])
+      status 200
+
+      %Q{
+        <cas:serviceResponse xmlns:cas="http://www.yale.edu/tp/cas">
+          <cas:proxySuccess>
+            <cas:proxyTicket>#{pt.nonce}</cas:proxyTicket>
+          </cas:proxySuccess>
+        </cas:serviceResponse>
+      }
+    else
+      status 401
+
+      %Q{
+        <cas:serviceResponse xmlns:cas="http://www.yale.edu/tp/cas">
+          <cas:authenticationFailure code="INVALID_TICKET">
+          </cas:authenticationFailure>
+        </cas:serviceResponse>
+      }
+    end
+  end
+
+  run! if app_file == $0
+end


### PR DESCRIPTION
I would like Aker's tests to run with ActiveSupport 4.x -- there's nothing in Aker proper that won't work with it.  This is the most future-proof and direct way I could think of; other suggestions welcome.

Here's why I chose this route (from ff22b7291997cde692125efce31e7bf5cae6d9b7):

```
Justification:

1. Aker-Rails needs to officially support Rails 4.x.
2. To satisfy (1), Aker must work with ActiveSupport 4.x.
3. To satisfy (2), all of Aker's tests must pass with ActiveSupport 4.x.
4. The version of RubyCAS-Server that we use (RS) does not work with
   ActiveSupport 4.x.
5. The most recent version of RubyCAS-Server (RS') also does not work with
   ActiveSupport 4.x.
6. The startup procedure for RS' differs from the procedure for RS.
7. The problem with RS' and ActiveSupport 4.x looks like adjustments for
   changes in ActiveRecord 4.x.  I've looked into them, but didn't make
   much headway into solving the problem.
8. We do not need a database connection (or even an embedded database)
   to run Aker's CAS tests; we just need the server component of the CAS
   protocol.

The TestCasServer component (features/support/test_cas.rb) is an
implementation of CAS 2.0.  It does not use a database, and has only two
direct dependencies: sinatra and escape_utils.
```

Of course, there's one big issue with this: _there's no way to know if this CAS server actually implements CAS._

I've run `castanet`'s test suite against the CAS server in this commit, and it passes, but all that's saying is that something I wrote against Jasig's CAS server also works against a CAS server I wrote.  So it's worth something, but not much.  If we had a standalone CAS server compliance test suite, that'd help a lot -- but I can't find anything like that out there.
